### PR TITLE
Add OracleFinder's CryptoCompare External Adapter

### DIFF
--- a/2018-07-30--cl-adapters/index.md
+++ b/2018-07-30--cl-adapters/index.md
@@ -33,7 +33,7 @@ External adapters are what make Chainlink easily extensible, providing simple in
 > Order a pizza  
 
 ## List of currently available Chainlink external adapters.
-There aren't too many implemented adapters that you can get your hands on right now, except the ones created the Linkpool Team. 
+There aren't too many implemented adapters that you can get your hands on right now, except the ones created by the Linkpool and [OracleFinder.com](https://oraclefinder.com/) Team. 
 ### [Asset Price Adapter](https://github.com/linkpoolio/asset-price-cl-ea)
 External Adapter for Chainlink which aggregates prices of crypto assets from multiple exchanges based on a weighted average of their volume.
 ### [XML -> JSON Adapter](https://github.com/linkpoolio/xml-cl-ea)
@@ -46,3 +46,5 @@ Iota adapter for Chainlink that currently supports the following IOTA API querie
 > getAccountData  
 > getNodeInfo  
 > sendTrytes  
+### [CryptoCompare External Adapter](https://github.com/OracleFinder/CryptoCompareExternalAdapter)
+Adapter to get data from CryptoCompare.com. Built to be deployed on GCP Cloud Functions or AWS Lambda.


### PR DESCRIPTION
<!-- Please follow the provided format. Fill in title, subtitle and category-->  
<!-- Valid categories are: confirmed OR speculation -->  

---
title: CryptoCompare External Adapter
subTitle: Adapter to get data from CryptoCompare.com. Built to be deployed on GCP Cloud Functions or AWS Lambda.
category: "adapters"  
cover: photo.jpg <!-- Don't touch this line -->  
---

# CryptoCompare External Adapter
Adapter to get data from CryptoCompare.com. Built to be deployed on GCP Cloud Functions or AWS Lambda.