### PR TITLE
Add OracleFinder's CoinMarketCap External Adapter

### DIFF
--- a/2018-07-30--cl-adapters/index.md
+++ b/2018-07-30--cl-adapters/index.md
@@ -48,3 +48,5 @@ Iota adapter for Chainlink that currently supports the following IOTA API querie
 > sendTrytes  
 ### [CryptoCompare External Adapter](https://github.com/OracleFinder/CryptoCompareExternalAdapter)
 Adapter to get data from CryptoCompare.com. Built to be deployed on GCP Cloud Functions or AWS Lambda.
+### [CoinMarketCap External Adapter](https://github.com/OracleFinder/CMCExternalAdapter)
+Adapter to get data from the CoinMarketCap.com API, both free and paid. Built to be instantly deployed on GCP Cloud Functions or AWS Lambda.


### PR DESCRIPTION
<!-- Please follow the provided format. Fill in title, subtitle and category-->  
<!-- Valid categories are: confirmed OR speculation -->  

---
title: CoinMarketCap External Adapter
subTitle: Adapter to get data from the CoinMarketCap.com API, both free and paid. Built to be instantly deployed on GCP Cloud Functions or AWS Lambda.
category: "adapters"  
cover: photo.jpg <!-- Don't touch this line -->  
---

# CoinMarketCap External Adapter
Adapter to get data from the CoinMarketCap.com API, both free and paid. Built to be instantly deployed on GCP Cloud Functions or AWS Lambda.
